### PR TITLE
Fix for dev tools usability

### DIFF
--- a/run.go
+++ b/run.go
@@ -89,7 +89,7 @@ func Run(o Options) (err error) {
 		var debug bool
 		width := *o.WindowOptions.Width
 		mi := &astilectron.MenuItemOptions{
-			Accelerator: astilectron.NewAccelerator("d"),
+			Accelerator: astilectron.NewAccelerator("CmdOrCtrl+d"),
 			Label:       astiptr.Str("Debug"),
 			OnClick: func(e astilectron.Event) (deleteListener bool) {
 				if debug {


### PR DESCRIPTION
Changed the accelerator shortcut to <kbd>CMD+d</kbd> or <kbd>CTRL+d</kbd>

Refs #4 