### PR TITLE
custom resource path

### DIFF
--- a/options.go
+++ b/options.go
@@ -10,7 +10,6 @@ type Options struct {
 	AstilectronOptions astilectron.Options
 	Debug              bool
 	HomeResource       string
-	HomeDirectory      string
 	Homepage           string
 	MenuOptions        []*astilectron.MenuItemOptions
 	MessageHandler     MessageHandler

--- a/options.go
+++ b/options.go
@@ -9,7 +9,7 @@ type Options struct {
 	Asset              Asset
 	AstilectronOptions astilectron.Options
 	Debug              bool
-	HomeResource       string
+	ResourcesPath      string
 	Homepage           string
 	MenuOptions        []*astilectron.MenuItemOptions
 	MessageHandler     MessageHandler

--- a/options.go
+++ b/options.go
@@ -9,7 +9,7 @@ type Options struct {
 	Asset              Asset
 	AstilectronOptions astilectron.Options
 	Debug              bool
-	HomeResource       string
+	ResourcesPath       string
 	Homepage           string
 	MenuOptions        []*astilectron.MenuItemOptions
 	MessageHandler     MessageHandler

--- a/options.go
+++ b/options.go
@@ -9,6 +9,7 @@ type Options struct {
 	Asset              Asset
 	AstilectronOptions astilectron.Options
 	Debug              bool
+	HomeDirectory      string
 	Homepage           string
 	MenuOptions        []*astilectron.MenuItemOptions
 	MessageHandler     MessageHandler

--- a/options.go
+++ b/options.go
@@ -9,7 +9,7 @@ type Options struct {
 	Asset              Asset
 	AstilectronOptions astilectron.Options
 	Debug              bool
-	ResourcesPath       string
+	ResourcesPath      string
 	Homepage           string
 	MenuOptions        []*astilectron.MenuItemOptions
 	MessageHandler     MessageHandler

--- a/options.go
+++ b/options.go
@@ -9,6 +9,7 @@ type Options struct {
 	Asset              Asset
 	AstilectronOptions astilectron.Options
 	Debug              bool
+	HomeResource       string
 	HomeDirectory      string
 	Homepage           string
 	MenuOptions        []*astilectron.MenuItemOptions

--- a/run.go
+++ b/run.go
@@ -9,7 +9,6 @@ import (
 	"github.com/asticode/go-astilog"
 	"github.com/asticode/go-astitools/ptr"
 	"github.com/pkg/errors"
-	"log"
 )
 
 // Run runs the bootstrap

--- a/run.go
+++ b/run.go
@@ -69,8 +69,14 @@ func Run(o Options) (err error) {
 
 	// Init window
 	var w *astilectron.Window
-	if w, err = a.NewWindow(filepath.Join(a.Paths().BaseDirectory(), "resources", "app", o.Homepage), o.WindowOptions); err != nil {
-		return errors.Wrap(err, "new window failed")
+	if o.HomeDirectory != "" {
+		if w, err = a.NewWindow(filepath.Join(a.Paths().BaseDirectory(), o.HomeDirectory, o.Homepage), o.WindowOptions); err != nil {
+			return errors.Wrap(err, "new window failed")
+		}
+	} else {
+		if w, err = a.NewWindow(filepath.Join(a.Paths().BaseDirectory(), "resources", "app", o.Homepage), o.WindowOptions); err != nil {
+			return errors.Wrap(err, "new window failed")
+		}
 	}
 
 	// Handle messages

--- a/run.go
+++ b/run.go
@@ -45,12 +45,17 @@ func Run(o Options) (err error) {
 		a.SetProvisioner(astibundler.NewProvisioner(o.Asset))
 	}
 
+	var homeResource string
+	if homeResource = o.HomeResource; homeResource == "" {
+		homeResource = "resources"
+	}
+
 	// Restore resources
 	if o.RestoreAssets != nil {
-		var rp = filepath.Join(a.Paths().BaseDirectory(), o.HomeResource)
+		var rp = filepath.Join(a.Paths().BaseDirectory(), homeResource)
 		if _, err = os.Stat(rp); os.IsNotExist(err) {
 			astilog.Debugf("Restoring resources in %s", rp)
-			if err = o.RestoreAssets(a.Paths().BaseDirectory(), o.HomeResource); err != nil {
+			if err = o.RestoreAssets(a.Paths().BaseDirectory(), homeResource); err != nil {
 				err = errors.Wrapf(err, "restoring resources in %s failed", rp)
 				return
 			}
@@ -69,14 +74,8 @@ func Run(o Options) (err error) {
 
 	// Init window
 	var w *astilectron.Window
-	if o.HomeDirectory != "" {
-		if w, err = a.NewWindow(filepath.Join(a.Paths().BaseDirectory(), o.HomeDirectory, o.Homepage), o.WindowOptions); err != nil {
-			return errors.Wrap(err, "new window failed")
-		}
-	} else {
-		if w, err = a.NewWindow(filepath.Join(a.Paths().BaseDirectory(), "resources", "app", o.Homepage), o.WindowOptions); err != nil {
-			return errors.Wrap(err, "new window failed")
-		}
+	if w, err = a.NewWindow(filepath.Join(a.Paths().BaseDirectory(), homeResource, o.Homepage), o.WindowOptions); err != nil {
+		return errors.Wrap(err, "new window failed")
 	}
 
 	// Handle messages

--- a/run.go
+++ b/run.go
@@ -45,17 +45,17 @@ func Run(o Options) (err error) {
 		a.SetProvisioner(astibundler.NewProvisioner(o.Asset))
 	}
 
-	var homeResource string
-	if homeResource = o.HomeResource; homeResource == "" {
-		homeResource = "resources"
+	var resourcesPath string
+	if resourcesPath = o.ResourcesPath; resourcesPath == "" {
+		resourcesPath = "resources"
 	}
 
 	// Restore resources
 	if o.RestoreAssets != nil {
-		var rp = filepath.Join(a.Paths().BaseDirectory(), homeResource)
+		var rp = filepath.Join(a.Paths().BaseDirectory(), resourcesPath)
 		if _, err = os.Stat(rp); os.IsNotExist(err) {
 			astilog.Debugf("Restoring resources in %s", rp)
-			if err = o.RestoreAssets(a.Paths().BaseDirectory(), homeResource); err != nil {
+			if err = o.RestoreAssets(a.Paths().BaseDirectory(), resourcesPath); err != nil {
 				err = errors.Wrapf(err, "restoring resources in %s failed", rp)
 				return
 			}
@@ -74,7 +74,7 @@ func Run(o Options) (err error) {
 
 	// Init window
 	var w *astilectron.Window
-	if w, err = a.NewWindow(filepath.Join(a.Paths().BaseDirectory(), homeResource, o.Homepage), o.WindowOptions); err != nil {
+	if w, err = a.NewWindow(filepath.Join(a.Paths().BaseDirectory(), resourcesPath, o.Homepage), o.WindowOptions); err != nil {
 		return errors.Wrap(err, "new window failed")
 	}
 

--- a/run.go
+++ b/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/asticode/go-astilog"
 	"github.com/asticode/go-astitools/ptr"
 	"github.com/pkg/errors"
+	"log"
 )
 
 // Run runs the bootstrap
@@ -47,10 +48,10 @@ func Run(o Options) (err error) {
 
 	// Restore resources
 	if o.RestoreAssets != nil {
-		var rp = filepath.Join(a.Paths().BaseDirectory(), "resources")
+		var rp = filepath.Join(a.Paths().BaseDirectory(), o.HomeResource)
 		if _, err = os.Stat(rp); os.IsNotExist(err) {
 			astilog.Debugf("Restoring resources in %s", rp)
-			if err = o.RestoreAssets(a.Paths().BaseDirectory(), "resources"); err != nil {
+			if err = o.RestoreAssets(a.Paths().BaseDirectory(), o.HomeResource); err != nil {
 				err = errors.Wrapf(err, "restoring resources in %s failed", rp)
 				return
 			}

--- a/run.go
+++ b/run.go
@@ -45,17 +45,17 @@ func Run(o Options) (err error) {
 		a.SetProvisioner(astibundler.NewProvisioner(o.Asset))
 	}
 
-	var homeResource string
-	if homeResource = o.HomeResource; homeResource == "" {
-		homeResource = "resources"
+	var resourcesPath string
+	if resourcesPath = o.ResourcesPath; resourcesPath == "" {
+    resourcesPath = "resources"
 	}
 
 	// Restore resources
 	if o.RestoreAssets != nil {
-		var rp = filepath.Join(a.Paths().BaseDirectory(), homeResource)
+		var rp = filepath.Join(a.Paths().BaseDirectory(), resourcesPath)
 		if _, err = os.Stat(rp); os.IsNotExist(err) {
 			astilog.Debugf("Restoring resources in %s", rp)
-			if err = o.RestoreAssets(a.Paths().BaseDirectory(), homeResource); err != nil {
+			if err = o.RestoreAssets(a.Paths().BaseDirectory(), resourcesPath); err != nil {
 				err = errors.Wrapf(err, "restoring resources in %s failed", rp)
 				return
 			}
@@ -74,7 +74,7 @@ func Run(o Options) (err error) {
 
 	// Init window
 	var w *astilectron.Window
-	if w, err = a.NewWindow(filepath.Join(a.Paths().BaseDirectory(), homeResource, o.Homepage), o.WindowOptions); err != nil {
+	if w, err = a.NewWindow(filepath.Join(a.Paths().BaseDirectory(), resourcesPath, o.Homepage), o.WindowOptions); err != nil {
 		return errors.Wrap(err, "new window failed")
 	}
 


### PR DESCRIPTION
I'm use the **go-astilectron-demo** firstly. It use "resources" structure, like the code in [main.go](https://github.com/asticode/go-astilectron-demo/blob/f4bc42d96dc42668c59e6ed69f62bfcaabade4f7/main.go#L34).

resources structure:

```

resources/
       |-app/
             |- index.html
             |-static
       |-icon.png
       |-...

```

main.go:

```

if err := bootstrap.Run(bootstrap.Options{
	Asset: Asset,
	AstilectronOptions: astilectron.Options{
		AppName:            AppName,
		AppIconDarwinPath:  "resources/icon.icns",
		AppIconDefaultPath: "resources/icon.png",
	},
	Debug:    *debug,
	Homepage: "index.html",       // this refers to resources/app/index.html in bootstrap, see bootstrap run.go:72
        .....

```

Yet in `go-astilectron-bundler` provide a way that change resources path in [bundler.go](https://github.com/asticode/go-astilectron-bundler/blob/c9aa756170b8ee1a40f9f3640d34e8f6fbc80f6b/bundler.go#L168):

```

// Resources path
if b.pathResources, err = absPath(c.ResourcesPath, func() (string, error) { return filepath.Join(b.pathInput, "resources"), nil }); err != nil {
	return
}

```

It can customly config **resources_path** in **bundler.json** to set the resources path, such as:

```
      
 resources_path: "xxxproject/dist"            // I think that nowadays many one use vue or react in production will generate like this structure instead of "resources" structure above.

```

However in `go-astilectron-bootstrap` is use stable path in homepage and restoreAssets in [run.go](https://github.com/asticode/go-astilectron-bootstrap/blob/f62b8563e2ffa1d1b7a1ba1aa016a2705ee997b0/run.go#L48):

```

// Restore resources
if o.RestoreAssets != nil {
	var rp = filepath.Join(a.Paths().BaseDirectory(), "resources")
	if _, err = os.Stat(rp); os.IsNotExist(err) {
		astilog.Debugf("Restoring resources in %s", rp)
		if err = o.RestoreAssets(a.Paths().BaseDirectory(), "resources"); err != nil {
			err = errors.Wrapf(err, "restoring resources in %s failed", rp)
			return
		}
	} else if err != nil {
		err = errors.Wrapf(err, "stating %s failed", rp)
		return
	} else {
		astilog.Debugf("%s already exists, skipping restoring resources...", rp)
	}
}

// Start
if err = a.Start(); err != nil {
	return errors.Wrap(err, "starting astilectron failed")
}

// Init window
var w *astilectron.Window
if w, err = a.NewWindow(filepath.Join(a.Paths().BaseDirectory(), "resources", "app", o.Homepage), o.WindowOptions); err != nil {
	return errors.Wrap(err, "new window failed")
}

```

I add `HomeResources` attr to help set the customly path setting in bootstrap.
I think if you merge this PR, It may have some changes with `go-astilectron-demo`
