### PR TITLE
Support multiple windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-This package allows you to quickly create a one-window application using [astilectron](https://github.com/asticode/go-astilectron).
+This package allows you to quickly create a multi-window application using [astilectron](https://github.com/asticode/go-astilectron).
 
 Check out the [demo](https://github.com/asticode/go-astilectron-demo) to see a working example with the [bundler](https://github.com/asticode/go-astilectron-bundler).

--- a/options.go
+++ b/options.go
@@ -10,16 +10,21 @@ type Options struct {
 	AssetDir           AssetDir
 	AstilectronOptions astilectron.Options
 	Debug              bool
-	Homepage           string
 	MenuOptions        []*astilectron.MenuItemOptions
-	MessageHandler     MessageHandler
 	OnWait             OnWait
 	ResourcesPath      string
 	RestoreAssets      RestoreAssets
 	TrayMenuOptions    []*astilectron.MenuItemOptions
 	TrayOptions        *astilectron.TrayOptions
+        Windows            []*Window
+}
+
+// Options to setup and create a new window
+type Window struct {
+	Homepage           string
+	MessageHandler     MessageHandler
+        WindowOptions      *astilectron.WindowOptions
 	WindowAdapter      WindowAdapter
-	WindowOptions      *astilectron.WindowOptions
 }
 
 // Asset is a function that retrieves an asset content namely the go-bindata's Asset method
@@ -32,7 +37,7 @@ type AssetDir func(name string) ([]string, error)
 type MessageHandler func(w *astilectron.Window, m MessageIn) (payload interface{}, err error)
 
 // OnWait is a function that executes custom actions before waiting
-type OnWait func(a *astilectron.Astilectron, w *astilectron.Window, m *astilectron.Menu, t *astilectron.Tray, tm *astilectron.Menu) error
+type OnWait func(a *astilectron.Astilectron, w []*astilectron.Window, m *astilectron.Menu, t *astilectron.Tray, tm *astilectron.Menu) error
 
 // RestoreAssets is a function that restores assets namely the go-bindata's RestoreAssets method
 type RestoreAssets func(dir, name string) error


### PR DESCRIPTION
Updates bootstrap to support multi-window applications. This is done through the definition of a new Windows key on bootstrap.WindowOptions, allowing users to define and customize support for as many windows as they need.

This does have a downside of breaking the pre-existing API (and necessitating a change in the function signature of OnWait), but it's pretty minimal and I strongly feel that this modification unlocks a ton more value from this bootstrapper.

NOTE: I have not modified the demo repo to support this new API structure.