### PR TITLE
Astilectron adapter

### DIFF
--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ import (
 
 // Options represents options
 type Options struct {
+	Adapter            AstilectronAdapter
 	Asset              Asset
 	AssetDir           AssetDir
 	AstilectronOptions astilectron.Options
@@ -26,6 +27,9 @@ type Window struct {
 	MessageHandler MessageHandler
 	Options        *astilectron.WindowOptions
 }
+
+// AstilectronAdapter is a function that adapts the astilectron instance
+type AstilectronAdapter func(w *astilectron.Astilectron)
 
 // Asset is a function that retrieves an asset content namely the go-bindata's Asset method
 type Asset func(name string) ([]byte, error)

--- a/run.go
+++ b/run.go
@@ -44,6 +44,11 @@ func Run(o Options) (err error) {
 	defer a.Close()
 	a.HandleSignals()
 
+	// Adapt astilectron
+	if o.Adapter != nil {
+		o.Adapter(a)
+	}
+
 	// Set provisioner
 	if o.Asset != nil {
 		a.SetProvisioner(astibundler.NewProvisioner(o.Asset))


### PR DESCRIPTION
Expose an adapter option for receiving the Astilectron ref before OnWait is called. This enables devs to add early listeners, call exposed methods, etc during the long bootstrap setup process. I'm personally using this to watch for events on the windows and propagate a proper Stop() call to astilectron on a window close during early startup (without exposing this in some way early, I was experiencing a multi-second delay between the user action and the desired Stop event being called).

Ran gofmt, tested on my own code.